### PR TITLE
Feurenard/mpa share

### DIFF
--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -5,6 +5,10 @@
           android:title="@string/media_preview__forward_title"
           android:icon="@drawable/ic_forward_white_24dp"
           app:showAsAction="always"/>
+    <item android:id="@+id/action_share"
+          android:title="Share"
+          app:showAsAction="always"
+          app:actionProviderClass="android.support.v7.widget.ShareActionProvider"/>
     <item android:id="@+id/save"
           android:title="@string/media_preview__save_title"
           android:icon="@drawable/ic_save_white_24dp"

--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -5,10 +5,10 @@
           android:title="@string/media_preview__forward_title"
           android:icon="@drawable/ic_forward_white_24dp"
           app:showAsAction="always"/>
-    <item android:id="@+id/action_share"
+    <item android:id="@+id/share"
           android:title="Share"
-          app:showAsAction="always"
-          app:actionProviderClass="android.support.v7.widget.ShareActionProvider"/>
+          android:icon="@drawable/ic_share_white_24dp"
+          app:showAsAction="always"/>
     <item android:id="@+id/save"
           android:title="@string/media_preview__save_title"
           android:icon="@drawable/ic_save_white_24dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1260,6 +1260,7 @@
     <string name="MediaPreviewActivity_you">You</string>
     <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
     <string name="MediaPreviewActivity_unssuported_media_type">Unsupported media type</string>
+    <string name="MediaPreviewActivity_share_via">Share via</string>
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -523,7 +523,8 @@ public class ConversationItem extends LinearLayout
       Log.w(TAG, "Clicked: " + slide.getUri() + " , " + slide.getContentType());
       Intent intent = new Intent(Intent.ACTION_VIEW);
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-      intent.setDataAndType(PartAuthority.getAttachmentPublicUri(slide.getUri()), slide.getContentType());
+      intent.setDataAndType(PartAuthority.getAttachmentPublicUri(slide.getUri(), slide.getContentType()),
+                            slide.getContentType());
       try {
         context.startActivity(intent);
       } catch (ActivityNotFoundException anfe) {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -232,7 +232,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     intent.setType(mediaType);
     intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri, mediaType));
 
-    startActivity(Intent.createChooser(intent, "Choo-choo-choose me!"));
+    startActivity(Intent.createChooser(intent, getString(R.string.MediaPreviewActivity_share_via)));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -24,6 +24,8 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.view.MenuItemCompat;
+import android.support.v7.widget.ShareActionProvider;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -222,7 +224,20 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     inflater.inflate(R.menu.media_preview, menu);
     if (threadId == -1) menu.findItem(R.id.media_preview__overview).setVisible(false);
 
+    initializeShareAction(menu);
+
     return true;
+  }
+
+  private void initializeShareAction(Menu menu) {
+    MenuItem shareItem = menu.findItem(R.id.action_share);
+    ShareActionProvider shareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(shareItem);
+
+    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+    shareIntent.setType(mediaType);
+    shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUri);
+
+    shareActionProvider.setShareIntent(shareIntent);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -230,7 +230,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setType(mediaType);
-    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUriWithExtension(mediaUri, mediaType));
+    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri, mediaType));
 
     startActivity(Intent.createChooser(intent, "Choo-choo-choose me!"));
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -24,8 +24,6 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.ShareActionProvider;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -225,21 +223,16 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     inflater.inflate(R.menu.media_preview, menu);
     if (threadId == -1) menu.findItem(R.id.media_preview__overview).setVisible(false);
 
-    initializeShareAction(menu);
-
     return true;
   }
 
-  private void initializeShareAction(Menu menu) {
-    MenuItem shareItem = menu.findItem(R.id.action_share);
-    ShareActionProvider shareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(shareItem);
-
+  private void share() {
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setType(mediaType);
     intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri));
 
-    shareActionProvider.setShareIntent(intent);
+    startActivity(intent);
   }
 
   @Override
@@ -250,6 +243,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
       case R.id.media_preview__overview: showOverview(); return true;
       case R.id.media_preview__forward:  forward();      return true;
       case R.id.save:                    saveToDisk();   return true;
+      case R.id.share:                   share();        return true;
       case android.R.id.home:            finish();       return true;
     }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -36,6 +36,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipient.RecipientModifiedListener;
@@ -233,11 +234,12 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     MenuItem shareItem = menu.findItem(R.id.action_share);
     ShareActionProvider shareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(shareItem);
 
-    Intent shareIntent = new Intent(Intent.ACTION_SEND);
-    shareIntent.setType(mediaType);
-    shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUri);
+    Intent intent = new Intent(Intent.ACTION_SEND);
+    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    intent.setType(mediaType);
+    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri));
 
-    shareActionProvider.setShareIntent(shareIntent);
+    shareActionProvider.setShareIntent(intent);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -230,7 +230,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setType(mediaType);
-    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUriWithExtension(mediaUri));
+    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUriWithExtension(mediaUri, mediaType));
 
     startActivity(Intent.createChooser(intent, "Choo-choo-choose me!"));
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -230,9 +230,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setType(mediaType);
-    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri));
+    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUriWithExtension(mediaUri));
 
-    startActivity(intent);
+    startActivity(Intent.createChooser(intent, "Choo-choo-choose me!"));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -156,7 +156,6 @@ public class AttachmentDatabase extends Database {
     notifyConversationListeners(DatabaseFactory.getMmsDatabase(context).getThreadIdForMessage(mmsId));
   }
 
-  @VisibleForTesting
   public @Nullable DatabaseAttachment getAttachment(AttachmentId attachmentId) {
     SQLiteDatabase database = databaseHelper.getReadableDatabase();
     Cursor cursor           = null;

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -67,9 +67,9 @@ public class PartAuthority {
     return PartProvider.getContentUri(partUri.getPartId());
   }
 
-  public static Uri getAttachmentPublicUriWithExtension(Uri uri) {
+  public static Uri getAttachmentPublicUriWithExtension(Uri uri, String mimeType) {
     PartUriParser partUri = new PartUriParser(uri);
-    return PartProvider.getContentUriWithExtension(partUri.getPartId());
+    return PartProvider.getContentUriWithExtension(partUri.getPartId(), mimeType);
   }
 
   public static Uri getAttachmentDataUri(AttachmentId attachmentId) {

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -63,8 +63,17 @@ public class PartAuthority {
   }
 
   public static Uri getAttachmentPublicUri(Uri uri, String mimeType) {
-    PartUriParser partUri = new PartUriParser(uri);
-    return PartProvider.getContentUri(partUri.getPartId(), mimeType);
+    int match = uriMatcher.match(uri);
+    switch (match) {
+      case PART_ROW:
+      case THUMB_ROW:
+        PartUriParser partUri = new PartUriParser(uri);
+        return PartProvider.getPublicContentUri(partUri.getPartId(), mimeType);
+      case PERSISTENT_ROW:
+        return PartProvider.getPublicContentUri(ContentUris.parseId(uri), mimeType);
+      default:
+        return uri;
+    }
   }
 
   public static Uri getAttachmentDataUri(AttachmentId attachmentId) {

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -67,6 +67,11 @@ public class PartAuthority {
     return PartProvider.getContentUri(partUri.getPartId());
   }
 
+  public static Uri getAttachmentPublicUriWithExtension(Uri uri) {
+    PartUriParser partUri = new PartUriParser(uri);
+    return PartProvider.getContentUriWithExtension(partUri.getPartId());
+  }
+
   public static Uri getAttachmentDataUri(AttachmentId attachmentId) {
     Uri uri = Uri.withAppendedPath(PART_CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
     return ContentUris.withAppendedId(uri, attachmentId.getRowId());

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -62,14 +62,9 @@ public class PartAuthority {
     }
   }
 
-  public static Uri getAttachmentPublicUri(Uri uri) {
+  public static Uri getAttachmentPublicUri(Uri uri, String mimeType) {
     PartUriParser partUri = new PartUriParser(uri);
-    return PartProvider.getContentUri(partUri.getPartId());
-  }
-
-  public static Uri getAttachmentPublicUriWithExtension(Uri uri, String mimeType) {
-    PartUriParser partUri = new PartUriParser(uri);
-    return PartProvider.getContentUriWithExtension(partUri.getPartId(), mimeType);
+    return PartProvider.getContentUri(partUri.getPartId(), mimeType);
   }
 
   public static Uri getAttachmentDataUri(AttachmentId attachmentId) {

--- a/src/org/thoughtcrime/securesms/mms/PartUriParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PartUriParser.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.mms;
 
-import android.content.ContentUris;
 import android.net.Uri;
 
 import org.thoughtcrime.securesms.attachments.AttachmentId;
@@ -18,11 +17,7 @@ public class PartUriParser {
   }
 
   private long getId() {
-    try {
-      return ContentUris.parseId(uri);
-    } catch (NumberFormatException e) {
-      return Long.parseLong(uri.getPathSegments().get(2));
-    }
+    return Long.parseLong(uri.getPathSegments().get(2));
   }
 
   private long getUniqueId() {

--- a/src/org/thoughtcrime/securesms/mms/PartUriParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PartUriParser.java
@@ -18,7 +18,11 @@ public class PartUriParser {
   }
 
   private long getId() {
-    return ContentUris.parseId(uri);
+    try {
+      return ContentUris.parseId(uri);
+    } catch (NumberFormatException e) {
+      return Long.parseLong(uri.getPathSegments().get(2));
+    }
   }
 
   private long getUniqueId() {

--- a/src/org/thoughtcrime/securesms/mms/PersistentBlobUriParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PersistentBlobUriParser.java
@@ -1,0 +1,20 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.net.Uri;
+
+public class PersistentBlobUriParser {
+
+  private final Uri uri;
+
+  public PersistentBlobUriParser(Uri uri) {
+    this.uri = uri;
+  }
+
+  public long getId() {
+    return Long.parseLong(uri.getPathSegments().get(3));
+  }
+
+  public long getUniqueId() {
+    return Long.parseLong(uri.getPathSegments().get(2));
+  }
+}

--- a/src/org/thoughtcrime/securesms/providers/PartProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PartProvider.java
@@ -41,15 +41,17 @@ import java.io.InputStream;
 public class PartProvider extends ContentProvider {
   private static final String TAG = PartProvider.class.getSimpleName();
 
-  private static final String CONTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/part";
-  private static final Uri    CONTENT_URI        = Uri.parse(CONTENT_URI_STRING);
-  private static final int    SINGLE_ROW         = 1;
+  private static final String CONTENT_URI_STRING        = "content://org.thoughtcrime.provider.securesms/part";
+  private static final Uri    CONTENT_URI               = Uri.parse(CONTENT_URI_STRING);
+  private static final int    SINGLE_ROW                = 1;
+  private static final int    SINGLE_ROW_WITH_EXTENSION = 2;
 
   private static final UriMatcher uriMatcher;
 
   static {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#", SINGLE_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", SINGLE_ROW_WITH_EXTENSION);
   }
 
   @Override
@@ -61,6 +63,10 @@ public class PartProvider extends ContentProvider {
   public static Uri getContentUri(AttachmentId attachmentId) {
     Uri uri = Uri.withAppendedPath(CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
     return ContentUris.withAppendedId(uri, attachmentId.getRowId());
+  }
+
+  public static Uri getContentUriWithExtension(AttachmentId attachmentId) {
+    return getContentUri(attachmentId).buildUpon().appendEncodedPath("image.jpg").build();
   }
 
   @SuppressWarnings("ConstantConditions")
@@ -93,6 +99,7 @@ public class PartProvider extends ContentProvider {
 
     switch (uriMatcher.match(uri)) {
     case SINGLE_ROW:
+    case SINGLE_ROW_WITH_EXTENSION:
       Log.w(TAG, "Parting out a single row...");
       try {
         PartUriParser        partUri = new PartUriParser(uri);

--- a/src/org/thoughtcrime/securesms/providers/PartProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PartProvider.java
@@ -46,17 +46,15 @@ import java.io.InputStream;
 public class PartProvider extends ContentProvider {
   private static final String TAG = PartProvider.class.getSimpleName();
 
-  private static final String CONTENT_URI_STRING        = "content://org.thoughtcrime.provider.securesms/part";
-  private static final Uri    CONTENT_URI               = Uri.parse(CONTENT_URI_STRING);
-  private static final int    SINGLE_ROW                = 1;
-  private static final int    SINGLE_ROW_WITH_EXTENSION = 2;
+  private static final String CONTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/part";
+  private static final Uri    CONTENT_URI        = Uri.parse(CONTENT_URI_STRING);
+  private static final int    SINGLE_ROW         = 1;
 
   private static final UriMatcher uriMatcher;
 
   static {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#", SINGLE_ROW);
-    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", SINGLE_ROW_WITH_EXTENSION);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", SINGLE_ROW);
   }
 
   @Override
@@ -65,15 +63,14 @@ public class PartProvider extends ContentProvider {
     return true;
   }
 
-  public static Uri getContentUri(AttachmentId attachmentId) {
-    Uri uri = Uri.withAppendedPath(CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
-    return ContentUris.withAppendedId(uri, attachmentId.getRowId());
-  }
-
-  public static Uri getContentUriWithExtension(AttachmentId attachmentId, String mimeType) {
+  public static Uri getContentUri(AttachmentId attachmentId, String mimeType) {
     final String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
     final String filename  = "attachment." + (extension != null ? extension : "jpg");
-    return getContentUri(attachmentId).buildUpon().appendEncodedPath(filename).build();
+    final Uri    uri       = Uri.withAppendedPath(CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
+    return ContentUris.withAppendedId(uri, attachmentId.getRowId())
+                      .buildUpon()
+                      .appendEncodedPath(filename)
+                      .build();
   }
 
   @SuppressWarnings("ConstantConditions")
@@ -106,7 +103,6 @@ public class PartProvider extends ContentProvider {
 
     switch (uriMatcher.match(uri)) {
     case SINGLE_ROW:
-    case SINGLE_ROW_WITH_EXTENSION:
       Log.w(TAG, "Parting out a single row...");
       try {
         PartUriParser        partUri = new PartUriParser(uri);
@@ -136,7 +132,6 @@ public class PartProvider extends ContentProvider {
   public String getType(@NonNull Uri uri) {
     switch (uriMatcher.match(uri)) {
       case SINGLE_ROW:
-      case SINGLE_ROW_WITH_EXTENSION:
         PartUriParser      partUri    = new PartUriParser(uri);
         AttachmentDatabase database   = DatabaseFactory.getAttachmentDatabase(getContext());
         DatabaseAttachment attachment = database.getAttachment(partUri.getPartId());

--- a/src/org/thoughtcrime/securesms/providers/PartProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PartProvider.java
@@ -27,6 +27,7 @@ import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore.MediaColumns;
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
@@ -69,8 +70,10 @@ public class PartProvider extends ContentProvider {
     return ContentUris.withAppendedId(uri, attachmentId.getRowId());
   }
 
-  public static Uri getContentUriWithExtension(AttachmentId attachmentId) {
-    return getContentUri(attachmentId).buildUpon().appendEncodedPath("image.jpg").build();
+  public static Uri getContentUriWithExtension(AttachmentId attachmentId, String mimeType) {
+    final String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+    final String filename  = "attachment." + (extension != null ? extension : "jpg");
+    return getContentUri(attachmentId).buildUpon().appendEncodedPath(filename).build();
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/src/org/thoughtcrime/securesms/providers/PartProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PartProvider.java
@@ -35,7 +35,9 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.mms.PartUriParser;
+import org.thoughtcrime.securesms.mms.PersistentBlobUriParser;
 import org.thoughtcrime.securesms.service.KeyCachingService;
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,15 +48,19 @@ import java.io.InputStream;
 public class PartProvider extends ContentProvider {
   private static final String TAG = PartProvider.class.getSimpleName();
 
-  private static final String CONTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/part";
-  private static final Uri    CONTENT_URI        = Uri.parse(CONTENT_URI_STRING);
-  private static final int    SINGLE_ROW         = 1;
+  private static final String PART_URI_STRING       = "content://org.thoughtcrime.provider.securesms/part";
+  private static final String PERSISTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/capture";
+  private static final Uri    PART_URI              = Uri.parse(PART_URI_STRING);
+  private static final Uri    PERSISTENT_URI        = Uri.parse(PERSISTENT_URI_STRING);
+  private static final int    PART_ROW              = 1;
+  private static final int    PERSISTENT_ROW        = 2;
 
   private static final UriMatcher uriMatcher;
 
   static {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", SINGLE_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", PART_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "capture/*/*/#/*", PERSISTENT_ROW);
   }
 
   @Override
@@ -63,19 +69,27 @@ public class PartProvider extends ContentProvider {
     return true;
   }
 
-  public static Uri getContentUri(AttachmentId attachmentId, String mimeType) {
+  public static Uri getPublicContentUri(AttachmentId partId, String mimeType) {
+    final Uri uri = Uri.withAppendedPath(PART_URI, String.valueOf(partId.getUniqueId()));
+    return getPublicContentUri(ContentUris.withAppendedId(uri, partId.getRowId()), mimeType);
+  }
+
+  public static Uri getPublicContentUri(long persistentBlobId, String mimeType) {
+    final Uri uri = PERSISTENT_URI.buildUpon()
+                                  .appendPath(mimeType)
+                                  .appendEncodedPath(String.valueOf(System.currentTimeMillis()))
+                                  .build();
+    return getPublicContentUri(ContentUris.withAppendedId(uri, persistentBlobId), mimeType);
+  }
+
+  private static Uri getPublicContentUri(Uri base, String mimeType) {
     final String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
     final String filename  = "attachment." + (extension != null ? extension : "jpg");
-    final Uri    uri       = Uri.withAppendedPath(CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
-    return ContentUris.withAppendedId(uri, attachmentId.getRowId())
-                      .buildUpon()
-                      .appendEncodedPath(filename)
-                      .build();
+    return base.buildUpon().appendEncodedPath(filename).build();
   }
 
   @SuppressWarnings("ConstantConditions")
-  private File copyPartToTemporaryFile(MasterSecret masterSecret, AttachmentId attachmentId) throws IOException {
-    InputStream in        = DatabaseFactory.getAttachmentDatabase(getContext()).getAttachmentStream(masterSecret, attachmentId);
+  private File copyPartToTemporaryFile(InputStream in) throws IOException {
     File tmpDir           = getContext().getDir("tmp", 0);
     File tmpFile          = File.createTempFile("test", ".jpg", tmpDir);
     FileOutputStream fout = new FileOutputStream(tmpFile);
@@ -101,26 +115,38 @@ public class PartProvider extends ContentProvider {
       return null;
     }
 
-    switch (uriMatcher.match(uri)) {
-    case SINGLE_ROW:
-      Log.w(TAG, "Parting out a single row...");
-      try {
-        PartUriParser        partUri = new PartUriParser(uri);
-        File                 tmpFile = copyPartToTemporaryFile(masterSecret, partUri.getPartId());
-        ParcelFileDescriptor pdf     = ParcelFileDescriptor.open(tmpFile, ParcelFileDescriptor.MODE_READ_ONLY);
-
-        if (!tmpFile.delete()) {
-          Log.w(TAG, "Failed to delete temp file.");
-        }
-
-        return pdf;
-      } catch (IOException ioe) {
-        Log.w(TAG, ioe);
-        throw new FileNotFoundException("Error opening file");
-      }
+    int match = uriMatcher.match(uri);
+    if (match != PART_ROW && match != PERSISTENT_ROW) {
+      throw new FileNotFoundException("Request for bad part.");
     }
 
-    throw new FileNotFoundException("Request for bad part.");
+    try {
+      InputStream in;
+      switch (match) {
+      case PART_ROW:
+        Log.w(TAG, "Parting out a single row...");
+        PartUriParser partUri = new PartUriParser(uri);
+        in = DatabaseFactory.getAttachmentDatabase(getContext())
+                            .getAttachmentStream(masterSecret, partUri.getPartId());
+        break;
+      default:
+        PersistentBlobUriParser blobUri = new PersistentBlobUriParser(uri);
+        in = PersistentBlobProvider.getInstance(getContext()).getStream(masterSecret, blobUri.getId());
+      }
+
+      File                 tmpFile = copyPartToTemporaryFile(in);
+      ParcelFileDescriptor pdf     = ParcelFileDescriptor.open(tmpFile, ParcelFileDescriptor.MODE_READ_ONLY);
+
+      if (!tmpFile.delete()) {
+        Log.w(TAG, "Failed to delete temp file.");
+      }
+
+      return pdf;
+    } catch (IOException ioe) {
+      Log.w(TAG, ioe);
+      throw new FileNotFoundException("Error opening file");
+    }
+
   }
 
   @Override
@@ -130,14 +156,9 @@ public class PartProvider extends ContentProvider {
 
   @Override
   public String getType(@NonNull Uri uri) {
-    switch (uriMatcher.match(uri)) {
-      case SINGLE_ROW:
-        PartUriParser      partUri    = new PartUriParser(uri);
-        AttachmentDatabase database   = DatabaseFactory.getAttachmentDatabase(getContext());
-        DatabaseAttachment attachment = database.getAttachment(partUri.getPartId());
-        if (attachment != null) return attachment.getContentType();
-    }
-    return null;
+    final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+    final String mimeType  = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase());
+    return MediaUtil.getCorrectedMimeType(mimeType);
   }
 
   @Override
@@ -153,14 +174,24 @@ public class PartProvider extends ContentProvider {
       projection = new String[] {MediaColumns._ID, MediaColumns.DATA};
     }
 
-    PartUriParser partUri = new PartUriParser(uri);
-    MatrixCursor  cursor  = new MatrixCursor(projection);
-    Object[]      row     = new Object[projection.length];
+    int match = uriMatcher.match(uri);
+    if (match != PART_ROW && match != PERSISTENT_ROW) {
+      return null;
+    }
+
+    PartUriParser           partUri = new PartUriParser(uri);
+    PersistentBlobUriParser blobUri = new PersistentBlobUriParser(uri);
+    MatrixCursor            cursor  = new MatrixCursor(projection);
+    Object[]                row     = new Object[projection.length];
 
     for (int i = 0; i < row.length; i++) {
       switch (projection[i]) {
-        case MediaColumns._ID:  row[i] = partUri.getPartId().getRowId(); break;
-        case MediaColumns.DATA: row[i] = uri.toString();                 break;
+      case MediaColumns._ID:
+        row[i] = (match == PART_ROW ? partUri.getPartId().getRowId() : blobUri.getId());
+        break;
+      case MediaColumns.DATA:
+        row[i] = uri.toString();
+        break;
       }
     }
 


### PR DESCRIPTION
Hey,

sorry for opening this against master, but I had to as I rebased your commits.

I think I mostly got this to work, but there are still some problems / open questions.

- Why did you add the `SINGLE_ROW_WITH_EXTENSION` stuff / append "image.jpg" to all URIs? You do this for all types of media, right? Do you remember why this was necessary? Maybe it's no longer needed with a working `getType()` implementation?
- Sharing drafts currently causes a crash (forwarding drafts causes some problems, too). Do you think this is worth fixing or should we disable sharing drafts (and forwarding as well, possibly)? Maybe there's still a valid use case...

Cheers!

edit:
- another todo: add share button to conversation view on message selection